### PR TITLE
Phase 1: OpenWebUI-compatible RAG API, embeddings, and pgvector integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and fill values
+
+# Postgres connection string (psycopg3)
+DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/aletheia
+
+# OpenAI
+OPENAI_API_KEY=sk-...
+OPENAI_CHAT_MODEL=gpt-4o
+OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_DIM=1536
+
+# CORS
+ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,http://localhost:8080

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,32 @@
+import os
+from dotenv import load_dotenv
+
+
+# Load .env from repo root by default
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+DEFAULT_ENV_PATH = os.path.join(REPO_ROOT, ".env")
+load_dotenv(DEFAULT_ENV_PATH)
+
+
+def env(key: str, default: str | None = None) -> str | None:
+    return os.getenv(key, default)
+
+
+DATABASE_URL = env(
+    "DATABASE_URL",
+    "postgresql+psycopg://postgres:postgres@localhost:5432/aletheia",
+)
+
+OPENAI_API_KEY = env("OPENAI_API_KEY")
+
+# Models
+OPENAI_CHAT_MODEL = env("OPENAI_CHAT_MODEL", "gpt-4o")
+OPENAI_EMBEDDING_MODEL = env("OPENAI_EMBEDDING_MODEL", "text-embedding-3-small")
+
+# Embedding dimension should match DB schema
+_emb_dim = env("EMBEDDING_DIM", "1536") or "1536"
+EMBEDDING_DIM = int(_emb_dim)
+
+# CORS
+_origins = env("ALLOWED_ORIGINS", "http://localhost:3000,http://127.0.0.1:3000,http://localhost:8080") or "http://localhost:3000,http://127.0.0.1:3000,http://localhost:8080"
+ALLOWED_ORIGINS = [o.strip() for o in _origins.split(",") if o.strip()]

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,1 +1,15 @@
-# This file is intentionally left blank.
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from app.config import DATABASE_URL
+
+
+engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+	db = SessionLocal()
+	try:
+		yield db
+	finally:
+		db.close()

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,14 +1,28 @@
-from sqlalchemy import Column, String, Float
+import uuid
+from sqlalchemy import Column, Text, Float, DateTime, func
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.dialects.postgresql import UUID, ARRAY
+from pgvector.sqlalchemy import Vector
+from app.config import EMBEDDING_DIM
+
 
 Base = declarative_base()
 
-class YourModel(Base):
-    __tablename__ = 'your_model'
 
-    id = Column(String, primary_key=True)
-    name = Column(String, nullable=False)
-    embedding = Column(Float, nullable=False)  # Adjust type as needed for pgvector
+class MemoryShard(Base):
+    __tablename__ = "memory_shards"
 
-    def __repr__(self):
-        return f"<YourModel(id={self.id}, name={self.name})>"
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    timestamp = Column(DateTime(timezone=True), server_default=func.now())
+    last_accessed = Column(DateTime(timezone=True))
+    user_id = Column(UUID(as_uuid=True), nullable=True)
+    content = Column(Text, nullable=False)
+    source_ids = Column(ARRAY(UUID(as_uuid=True)), nullable=True)
+    tags = Column(ARRAY(Text), nullable=True)
+    embedding = Column(Vector(EMBEDDING_DIM), nullable=False)
+    importance = Column(Float, nullable=True)
+    priority_score = Column(Float, nullable=True)
+    retention_policy = Column(Text, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"<MemoryShard id={self.id} user_id={self.user_id}>"

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,5 @@
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from dotenv import load_dotenv
@@ -7,16 +7,36 @@ import os
 
 
 # Load environment variables from .env file at startup
-load_dotenv(dotenv_path=os.path.join(os.path.dirname(os.path.dirname(__file__)), 'aletheia_api.env'))
+load_dotenv(dotenv_path=os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))
 
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from app.services.openai_service import OpenAIService
+from app.config import ALLOWED_ORIGINS, OPENAI_CHAT_MODEL
+from fastapi.middleware.cors import CORSMiddleware
+from app.db import get_db, engine
+from sqlalchemy.orm import Session
+from app.utils.embeddings import convert_to_embedding, semantic_search, save_embedding_to_db
+from app.db.models import Base
+from app.api.routes import router as api_router
+from sqlalchemy import text
 
 
 app = FastAPI()
+
+# CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Include additional API routes
+app.include_router(api_router)
 
 # Serve static files (for chat UI)
 app.mount("/static", StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static")), name="static")
@@ -41,3 +61,131 @@ async def openai_chat(request: ChatRequest):
 @app.get("/")
 def read_root():
     return {"message": "Hello, World!"}
+
+
+# RAG Chat endpoint: generates embedding from user prompt, searches memory_shards, adds context, and calls OpenAI
+class RAGChatRequest(BaseModel):
+    prompt: str
+    user_id: str | None = None
+    top_k: int = 5
+
+
+@app.post("/rag-chat")
+async def rag_chat(req: RAGChatRequest, db: Session = Depends(get_db)):
+    query_vec = convert_to_embedding(req.prompt)
+    results = semantic_search(db, query_vec, user_id=req.user_id, limit=req.top_k)
+    context_chunks = [r["content"] for r in results]
+    context_text = "\n\n---\n\n".join(context_chunks)
+    system_prompt = (
+        "You are a helpful assistant. Use the provided context if relevant. "
+        "Cite facts from context explicitly. If context is empty, answer normally."
+    )
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": f"Context:\n{context_text}\n\nQuestion: {req.prompt}"},
+    ]
+    service = OpenAIService()
+    response = service.chat(messages)
+    answer = response.choices[0].message.content
+    return {"answer": answer, "context": results}
+
+
+@app.on_event("startup")
+def on_startup():
+    # Create tables if they do not exist (dev convenience)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+        Base.metadata.create_all(bind=engine)
+    except Exception:
+        # Silent failure; prefer Alembic in production
+        pass
+
+
+# Index content into memory_shards
+from typing import Optional, List
+
+
+class IndexMemoryRequest(BaseModel):
+    content: str
+    user_id: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+
+@app.post("/index-memory")
+async def index_memory(req: IndexMemoryRequest, db: Session = Depends(get_db)):
+    emb = convert_to_embedding(req.content)
+    shard = save_embedding_to_db(db=db, content=req.content, embedding=emb, user_id=req.user_id, tags=req.tags)
+    return {"id": str(shard.id)}
+
+
+# OpenAI-compatible chat completions endpoint for OpenWebUI
+from time import time as _time
+from uuid import uuid4
+
+
+@app.post("/v1/chat/completions")
+async def v1_chat_completions(payload: dict, db: Session = Depends(get_db)):
+    # Expecting { model?: str, messages: [{role, content}, ...], stream?: bool }
+    messages = payload.get("messages", [])
+    model = payload.get("model")
+    # Heuristic: use last user message as query for retrieval
+    user_messages = [m for m in messages if m.get("role") == "user" and m.get("content")]
+    query_text = user_messages[-1]["content"] if user_messages else ""
+    context_results = []
+    if query_text:
+        qvec = convert_to_embedding(query_text)
+        context_results = semantic_search(db, qvec, limit=5)
+        context_text = "\n\n---\n\n".join(r["content"] for r in context_results)
+        # Prepend a system message with retrieved context
+        system_prompt = (
+            "You are a helpful assistant. Use the provided context if relevant. "
+            "Cite facts from context explicitly. If context is empty, answer normally."
+        )
+        messages = (
+            [{"role": "system", "content": system_prompt}, {"role": "user", "content": f"Context:\n{context_text}"}]
+            + messages
+        )
+
+    service = OpenAIService()
+    resp = service.chat(messages, model=model)
+    content = resp.choices[0].message.content
+    completion_id = f"chatcmpl-{uuid4()}"
+    created = int(_time())
+    out = {
+        "id": completion_id,
+        "object": "chat.completion",
+        "created": created,
+        "model": model or resp.model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        "aletheia_context": context_results,
+    }
+    return out
+
+
+@app.get("/v1/models")
+async def v1_models():
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": OPENAI_CHAT_MODEL,
+                "object": "model",
+                "created": 0,
+                "owned_by": "aletheia",
+            }
+        ],
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -1,26 +1,31 @@
-
 from fastapi import HTTPException
-import openai
-import os
-from dotenv import load_dotenv
+from openai import OpenAI
+from app.config import OPENAI_API_KEY, OPENAI_CHAT_MODEL
 
 
 class OpenAIService:
-    def __init__(self, api_key: str = None):
-        # Load environment variables if not already loaded
-        load_dotenv(dotenv_path=os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'aletheia_api.env'))
-        if api_key is None:
-            api_key = os.getenv('OPENAI_API_KEY')
-        if not api_key:
-            raise ValueError("OpenAI API key not found in environment variables.")
-        self.client = openai.OpenAI(api_key=api_key)
+    def __init__(self, api_key: str | None = None):
+        key = api_key or OPENAI_API_KEY
+        if not key:
+            raise ValueError("OPENAI_API_KEY not configured")
+        self.client = OpenAI(api_key=key)
 
-    def get_response(self, prompt: str) -> str:
+    def get_response(self, prompt: str, model: str | None = None) -> str:
         try:
             response = self.client.chat.completions.create(
-                model="gpt-4o",
-                messages=[{"role": "user", "content": prompt}]
+                model=model or OPENAI_CHAT_MODEL,
+                messages=[{"role": "user", "content": prompt}],
             )
             return response.choices[0].message.content
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+
+    def chat(self, messages: list[dict], model: str | None = None):
+        try:
+            response = self.client.chat.completions.create(
+                model=model or OPENAI_CHAT_MODEL,
+                messages=messages,
+            )
+            return response
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e))

--- a/app/utils/embeddings.py
+++ b/app/utils/embeddings.py
@@ -1,15 +1,49 @@
-def convert_to_embedding(data):
-    # Function to convert input data to pgvector embedding
-    pass
+from typing import List, Optional
+from openai import OpenAI
+from sqlalchemy.orm import Session
+from app.config import OPENAI_API_KEY, OPENAI_EMBEDDING_MODEL
+from app.db.models import MemoryShard
 
-def convert_from_embedding(embedding):
-    # Function to convert pgvector embedding back to original data
-    pass
 
-def save_embedding_to_db(embedding, db_session):
-    # Function to save the embedding to the PostgreSQL database
-    pass
+def convert_to_embedding(text_input: str) -> List[float]:
+    client = OpenAI(api_key=OPENAI_API_KEY)
+    result = client.embeddings.create(model=OPENAI_EMBEDDING_MODEL, input=text_input)
+    return result.data[0].embedding  # list[float]
 
-def retrieve_embedding_from_db(id, db_session):
-    # Function to retrieve an embedding from the PostgreSQL database
-    pass
+
+def save_embedding_to_db(
+    *,
+    db: Session,
+    content: str,
+    embedding: List[float],
+    user_id: Optional[str] = None,
+    tags: Optional[list[str]] = None,
+):
+    shard = MemoryShard(
+        content=content,
+        embedding=embedding,
+        user_id=user_id,
+        tags=tags,
+    )
+    db.add(shard)
+    db.commit()
+    db.refresh(shard)
+    return shard
+
+
+def semantic_search(db: Session, query_embedding: List[float], user_id: Optional[str] = None, limit: int = 5):
+    q = db.query(MemoryShard)
+    if user_id:
+        q = q.filter(MemoryShard.user_id == user_id)
+    q = q.order_by(MemoryShard.embedding.l2_distance(query_embedding)).limit(limit)
+    rows = q.all()
+    return [
+        {
+            "id": str(r.id),
+            "content": r.content,
+            "user_id": str(r.user_id) if r.user_id else None,
+            "tags": r.tags,
+            "distance": None,  # distance not returned by ORM; could add with annotate
+        }
+        for r in rows
+    ]

--- a/docs/Initial_Observations.md
+++ b/docs/Initial_Observations.md
@@ -1,0 +1,92 @@
+# Initial Observations and Roadmap
+
+Date: 2025-09-19
+
+## Repository Summary
+
+- Purpose: FastAPI service bridging OpenAI chat and a PostgreSQL database with pgvector for embeddings. Includes a simple static chat UI.
+- Entrypoint: `app/main.py` serves static UI, exposes `POST /openai-chat`, basic `GET /`.
+- OpenAI integration: `app/services/openai_service.py` uses OpenAI chat completions.
+- Database: `app/db/schema.sql` contains substantive DDL with `vector(1536)` columns; ORM is placeholder and mismatched.
+- Utilities: `app/utils/embeddings.py` is stubbed.
+- Frontend: `app/static/chat.html` minimal chat client hitting `/openai-chat`.
+- Requirements: Includes FastAPI, SQLAlchemy, pgvector, OpenAI SDK, dotenv; psycopg duplicated.
+
+## Key Findings
+
+1. README inaccuracies
+   - Project name/paths differ from repo (`openai_pgvector_api` vs `aletheia`).
+   - Run command suggests `python app/main.py`; correct is using `uvicorn app.main:app --reload`.
+
+2. Router not wired
+   - `app/api/routes.py` defines basic routes but isn’t included in `app/main.py`.
+
+3. Environment handling
+   - Code loads `aletheia_api.env` from nonstandard path; no `.env.example` exists.
+
+4. Database integration incomplete
+   - No SQLAlchemy engine/session wiring.
+   - ORM (`app/db/models.py`) does not match `schema.sql` and uses `Float` for embeddings instead of a vector type.
+   - No migrations (Alembic). Schema setup is manual via SQL file.
+
+5. Embeddings pipeline missing
+   - `app/utils/embeddings.py` contains only stubs; no endpoint to create/search embeddings.
+
+6. Operational hygiene
+   - No CORS, structured logging, or consistent error handling.
+   - No tests or CI.
+
+## What Works Today
+
+- Start the API with uvicorn (once env has `OPENAI_API_KEY`) and use `/chat` UI to send a prompt to OpenAI via `/openai-chat`.
+
+## Immediate Fixes (Quick Wins)
+
+- Update README for correct name and run steps.
+- Add `.env.example` with `OPENAI_API_KEY` and `DATABASE_URL`.
+- Clean `requirements.txt`: choose `psycopg[binary]` or `psycopg2-binary` (prefer psycopg3). Optionally pin versions.
+- Wire `app/api/routes.py` into `app/main.py` and add CORS middleware.
+- Provide an `if __name__ == "__main__":` uvicorn runner for convenience.
+
+## Near-Term Enhancements
+
+- Centralized config in `app/config.py` to read envs once (OpenAI key, DB URL, model names).
+- SQLAlchemy setup: engine and session in `app/db/__init__.py`.
+- Align ORM models to `schema.sql` and use pgvector’s SQLAlchemy `Vector` type.
+- Introduce Alembic migrations and document DB setup.
+- Implement basic embeddings endpoints:
+  - `POST /embeddings`: create/save embedding for text into `memory_shards`.
+  - `POST /search`: cosine distance/IVFFlat or brute-force `embedding <=> :vec` search.
+
+## AI Layer Improvements
+
+- Implement `app/utils/embeddings.py` using OpenAI `text-embedding-3-small`.
+- Enhance chat to optionally retrieve top-k memories and ground responses (lightweight RAG).
+- Support streaming responses in `/openai-chat` for better UX.
+
+## Tooling & Ops
+
+- Dockerfile and docker-compose for API + Postgres with pgvector.
+- Basic tests via pytest; mock OpenAI; integration tests against a test DB.
+- Optional lint/type-check (ruff, mypy) and GitHub Actions CI.
+
+## Stretch Goals
+
+- Auth (API keys or OAuth) and per-user scoping for data.
+- Observability (metrics, tracing, structured logs, request IDs).
+- Background workers for batch embedding generation and cleanup.
+- Retention policies and versioned memory shards.
+- Frontend UX improvements for chat and search results.
+
+## Acceptance Criteria for Quick-Win PR
+
+- Corrected README and added `.env.example`.
+- `uvicorn app.main:app --reload` works; `/health` returns healthy; `/chat` loads.
+- Router included; CORS enabled for localhost.
+- `requirements.txt` has a single psycopg flavor and installs cleanly.
+
+## Notes and Assumptions
+
+- Assumed PostgreSQL 14+ with `pgvector` extension available.
+- Assumed OpenAI SDK v1.x and models: `gpt-4o` for chat, `text-embedding-3-small` for embeddings.
+- Embedding dimension 1536 per schema.

--- a/docs/phase_1_embeddings.md
+++ b/docs/phase_1_embeddings.md
@@ -1,0 +1,159 @@
+# Phase 1 — OpenWebUI + Embeddings-backed RAG
+
+Date: 2025-09-19
+
+## 1) High-level overview
+
+Goal: Use OpenWebUI as the chat interface while the backend performs server-side RAG. The server embeds the user’s message, searches Postgres/pgvector for relevant context, and augments the Chat request sent to OpenAI.
+
+End-to-end flow:
+- OpenWebUI connects to our API using OpenAI-compatible endpoints (`/v1/models`, `/v1/chat/completions`).
+- On each chat message, our API:
+  1. Generates an embedding for the user’s last message (OpenAI `text-embedding-3-small`).
+  2. Queries `memory_shards` with pgvector for nearest matches.
+  3. Prepends retrieved context to the Chat messages.
+  4. Calls OpenAI Chat (`gpt-4o` by default) and returns a compatible response.
+
+Result: OpenWebUI continues to work as a standard OpenAI client, but answers are improved with your private memory store.
+
+
+## 2) What was implemented
+
+### OpenAI-compatible interface for OpenWebUI
+- `GET /v1/models`: returns the configured model (from `OPENAI_CHAT_MODEL`).
+- `POST /v1/chat/completions`: accepts OpenAI-style chat payloads, performs retrieval on the last user message, augments the system/user context, then calls OpenAI Chat and returns a standard response.
+
+### RAG building blocks
+- `POST /index-memory`: indexes content into the database by generating an embedding and inserting a `memory_shards` row.
+- `POST /rag-chat`: a direct test endpoint for RAG; returns `{ answer, context }` for debugging.
+
+### Database and ORM
+- `app/db/__init__.py`: SQLAlchemy engine and `get_db()` session dependency.
+- `app/db/models.py`: `MemoryShard` ORM model aligned with `schema.sql` (vector column via `pgvector.sqlalchemy.Vector(EMBEDDING_DIM)`).
+- Startup hook attempts to ensure `CREATE EXTENSION IF NOT EXISTS vector` (requires privileges) and calls `Base.metadata.create_all()` for development convenience.
+
+### Embeddings utilities
+- `app/utils/embeddings.py`:
+  - `convert_to_embedding(text)`: OpenAI embeddings (`OPENAI_EMBEDDING_MODEL`, default `text-embedding-3-small`).
+  - `save_embedding_to_db(...)`: persists a `MemoryShard` with `content`, `embedding`, `user_id`, and optional `tags`.
+  - `semantic_search(db, query_embedding, user_id?, limit=5)`: nearest-neighbor search using SQLAlchemy/pgvector; currently ordered by L2 distance.
+
+### OpenAI service
+- `app/services/openai_service.py`: centralizes OpenAI client creation and exposes `get_response(prompt)` and `chat(messages, model?)` using `OPENAI_CHAT_MODEL`.
+
+### App glue and config
+- CORS enabled with `ALLOWED_ORIGINS` for local UIs (OpenWebUI).
+- Included `app/api/routes.py` (hello and health routes).
+- `app/config.py` centralizes env configuration (`DATABASE_URL`, `OPENAI_API_KEY`, model names, `EMBEDDING_DIM`, CORS origins); loads `.env`.
+- `.env.example` added to document required variables.
+- `requirements.txt`: cleaned to use psycopg3 (`psycopg[binary]`), FastAPI, SQLAlchemy, pgvector, OpenAI, uvicorn, python-dotenv.
+
+
+## 3) How the pieces tie together
+
+- OpenWebUI → our API (OpenAI-compatible)
+  - Base URL: `http://localhost:8000/v1`
+  - API Key in OpenWebUI can be any non-empty string (the server uses your real key from `.env`).
+- Our API (FastAPI)
+  - Parses messages, embeds the latest user message, runs vector search in Postgres, constructs system/user context, calls OpenAI Chat.
+- Postgres + pgvector
+  - Stores `memory_shards` with a `vector(1536)` embedding (configurable via `EMBEDDING_DIM`).
+  - Retrieval sorts by vector distance.
+- OpenAI
+  - Chat: `gpt-4o` default (configurable via `OPENAI_CHAT_MODEL`).
+  - Embeddings: `text-embedding-3-small` (configurable via `OPENAI_EMBEDDING_MODEL`).
+
+
+## 4) Setup and usage
+
+### Environment
+- Copy and edit `.env`:
+  ```bash
+  cp .env.example .env
+  # set OPENAI_API_KEY and adjust DATABASE_URL if needed
+  ```
+
+### Database
+- Create DB and enable pgvector (privileged):
+  ```bash
+  createdb aletheia
+  psql -d aletheia -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+  ```
+
+### Install and run
+- Install deps and launch server:
+  ```bash
+  python -m venv .venv
+  source .venv/bin/activate
+  pip install -r requirements.txt
+  uvicorn app.main:app --reload
+  ```
+
+### Index content
+- Add content so RAG has something to retrieve:
+  ```bash
+  curl -X POST http://127.0.0.1:8000/index-memory \
+    -H 'Content-Type: application/json' \
+    -d '{
+      "content": "Aletheia is our FastAPI + pgvector service. Memory shards store text and embeddings.",
+      "user_id": "00000000-0000-0000-0000-000000000001",
+      "tags": ["docs","overview"]
+    }'
+  ```
+
+### Connect OpenWebUI
+- In OpenWebUI, add a provider:
+  - Base URL: `http://127.0.0.1:8000/v1`
+  - API Key: any value (e.g., `aletheia-local`)
+  - Model: `gpt-4o` (or whatever you set in `.env`)
+- Start chatting; the backend injects retrieved context under the hood.
+
+
+## 5) Checklist — What to do next
+
+### Retrieval quality & data model
+- [ ] Decide on distance metric (L2 vs cosine). For OpenAI embeddings, cosine is common.
+- [ ] Add an index (IVFFlat) on `embedding` for faster search at scale.
+- [ ] Align ORM to all required fields from `schema.sql` (we implemented `memory_shards` first).
+- [ ] Add basic filters (e.g., `user_id`, `tags`) in `semantic_search`.
+- [ ] Add a batch ingestion endpoint (`/ingest`) for multiple documents.
+
+### API & UX
+- [ ] Support streaming Chat completions (SSE) to match OpenAI behavior in OpenWebUI.
+- [ ] Return token usage (prompt/completion) when available.
+- [ ] Add a debug flag to include retrieved context snippets in responses for inspection.
+- [ ] Provide a `DELETE /memory/:id` and `PUT /memory/:id` for lifecycle management.
+
+### Ops & quality
+- [ ] Replace `create_all` with Alembic migrations; document DB migration flow.
+- [ ] Dockerfile + docker-compose (API + Postgres + pgvector). Preinstall extension.
+- [ ] Tests: unit tests for embeddings utils (mock OpenAI) and integration tests for retrieval.
+- [ ] Structured logging, request IDs, and better error handling.
+- [ ] Basic rate limiting (per-IP or per-key) and request validation.
+
+### Security & multi-tenancy
+- [ ] Authentication: API key or OAuth for write/search endpoints.
+- [ ] Enforce `user_id` scoping on reads/writes; consider row-level security policies.
+- [ ] Tighter CORS configuration per deployment environment.
+
+### Performance
+- [ ] Switch to cosine ops if chosen; add proper index with `lists` parameter.
+- [ ] Consider caching embeddings for repeated queries.
+- [ ] Add pagination/limits and response shaping for large result sets.
+
+### Documentation
+- [ ] Update README with new run instructions and OpenWebUI configuration steps.
+- [ ] Add an architecture diagram and a short RAG tutorial.
+
+
+## 6) Acceptance criteria for Phase 1
+- OpenWebUI can connect to `http://localhost:8000/v1` and list the model.
+- `/v1/chat/completions` returns answers that reflect indexed content when relevant.
+- `/index-memory` stores content, and subsequent queries retrieve it.
+- Config via `.env` works end-to-end; CORS allows local UIs.
+
+
+## 7) Notes and assumptions
+- Requires PostgreSQL with `pgvector` extension available.
+- Startup attempt to install `vector` extension may fail without privileges; manual creation is recommended in dev/prod.
+- Embedding dimension defaults to `1536`; keep consistent with chosen embedding model.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 FastAPI
-psycopg2-binary
 pgvector
 openai
 uvicorn


### PR DESCRIPTION
## Summary
This PR introduces Phase 1 of the Aletheia backend: an OpenWebUI-compatible API with a server-side RAG pipeline powered by OpenAI embeddings and pgvector in Postgres.

## What’s included
- OpenAI-compatible endpoints for OpenWebUI
  - GET /v1/models — return configured model
  - POST /v1/chat/completions — perform retrieval on last user message, augment context, call OpenAI, return standard shape
- RAG endpoints and utilities
  - POST /index-memory — embed + persist content as memory_shards
  - POST /rag-chat — direct RAG test endpoint (returns answer + retrieved context)
  - app/utils/embeddings.py — OpenAI embeddings, save helper, semantic search (L2 distance)
- Database & ORM
  - app/db/__init__.py — SQLAlchemy engine + get_db session
  - app/db/models.py — MemoryShard model using pgvector.sqlalchemy.Vector(EMBEDDING_DIM)
  - Startup: ensure vector extension (if permitted) + create_all (dev convenience)
- App glue & config
  - CORS enabled via ALLOWED_ORIGINS
  - Include router, add __main__ uvicorn runner
  - app/config.py centralizes env (DATABASE_URL, OPENAI_API_KEY, OPENAI_* models, EMBEDDING_DIM)
  - .env.example for easy setup
- Docs & deps
  - docs/Initial_Observations.md and docs/phase_1_embeddings.md
  - requirements.txt cleaned to use psycopg[binary] (psycopg3)

## How it works (high level)
1) OpenWebUI talks to this service via /v1 endpoints (OpenAI-compatible).
2) For each user message, we embed the text (text-embedding-3-small), search pgvector in memory_shards, prepend the retrieved context to the prompt, and call OpenAI chat (gpt-4o by default).
3) Responses are returned in OpenAI’s shape so OpenWebUI works out-of-the-box.

## Setup
- Copy .env.example to .env and set OPENAI_API_KEY and DATABASE_URL
- Ensure Postgres and pgvector extension are available:
  - psql -d aletheia -c 'CREATE EXTENSION IF NOT EXISTS vector;'
- Install and run:
  - python -m venv .venv && source .venv/bin/activate
  - pip install -r requirements.txt
  - uvicorn app.main:app --reload
- Index some content:
  - POST /index-memory with { content, user_id?, tags? }
- Configure OpenWebUI provider:
  - Base URL: http://127.0.0.1:8000/v1, API key any string, Model from /v1/models

## Follow-ups (next phase)
- Switch retrieval to cosine distance and add IVFFlat index
- Streaming responses for /v1/chat/completions
- Batch ingestion endpoint and filters (user_id, tags)
- Replace create_all with Alembic migrations
- Docker Compose (API + Postgres + pgvector)
- Tests (mock OpenAI, integration with test DB)
- Authn/Authz and per-user scoping

## Notes
- Startup vector extension creation may require privileges; otherwise create it manually.
- Embedding dimension defaults to 1536; keep consistent with selected embedding model.
